### PR TITLE
Add core services and minimal API endpoints

### DIFF
--- a/src/HolaBebe.Api/Program.cs
+++ b/src/HolaBebe.Api/Program.cs
@@ -1,4 +1,9 @@
 using HolaBebe.Application.Mapping;
+using HolaBebe.Application;
+using HolaBebe.Application.Dtos;
+using HolaBebe.Application.Services;
+using Microsoft.AspNetCore.Http;
+using System.Security.Claims;
 using HolaBebe.Infrastructure;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -6,6 +11,9 @@ var builder = WebApplication.CreateBuilder(args);
 MappingConfig.Register();
 
 builder.Services.AddInfrastructure(builder.Configuration);
+builder.Services.AddApplication();
+
+builder.Services.Configure<UserSettings>(builder.Configuration.GetSection("User"));
 
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
@@ -21,5 +29,71 @@ if (app.Environment.IsDevelopment())
 app.UseHttpsRedirection();
 
 app.MapGet("/", () => "Hola Bebe API");
+
+var api = app.MapGroup("/api/v1");
+
+api.MapGet("/me/profile", async (HttpContext http, IProfileService svc, IConfiguration cfg, CancellationToken ct) =>
+    {
+        var userId = GetUserId(http.User, cfg);
+        var profile = await svc.GetProfileAsync(userId, ct);
+        return profile is null ? Results.NotFound() : Results.Ok(profile);
+    })
+    .WithName("GetMyProfile")
+    .WithSummary("Get current user profile")
+    .WithDescription("Returns the authenticated user's profile. If none exists, returns 404.")
+    .Produces<UserProfileDto>(StatusCodes.Status200OK)
+    .Produces(StatusCodes.Status404NotFound)
+    .WithOpenApi();
+
+api.MapPut("/me/profile", async (UserProfileDto dto, HttpContext http, IProfileService svc, IConfiguration cfg, CancellationToken ct) =>
+    {
+        var userId = GetUserId(http.User, cfg);
+        var profile = await svc.UpsertProfileAsync(dto, userId, ct);
+        return Results.Ok(profile);
+    })
+    .WithName("UpsertMyProfile")
+    .WithSummary("Create or update user profile")
+    .Produces<UserProfileDto>(StatusCodes.Status200OK)
+    .WithOpenApi();
+
+api.MapPost("/pregnancies", async (PregnancyDto dto, HttpContext http, IPregnancyService svc, IConfiguration cfg, CancellationToken ct) =>
+    {
+        var userId = GetUserId(http.User, cfg);
+        var preg = await svc.CreatePregnancyAsync(dto, userId, ct);
+        return Results.Created($"/api/v1/pregnancies/{preg.Id}", preg);
+    })
+    .WithName("CreatePregnancy")
+    .WithSummary("Create pregnancy record")
+    .Produces<PregnancyDto>(StatusCodes.Status201Created)
+    .WithOpenApi();
+
+api.MapGet("/pregnancies/current", async (HttpContext http, IPregnancyService svc, IConfiguration cfg, CancellationToken ct) =>
+    {
+        var userId = GetUserId(http.User, cfg);
+        var preg = await svc.GetCurrentPregnancyAsync(userId, ct);
+        return preg is null ? Results.NotFound() : Results.Ok(preg);
+    })
+    .WithName("GetCurrentPregnancy")
+    .WithSummary("Get current pregnancy")
+    .Produces<PregnancyDto>(StatusCodes.Status200OK)
+    .Produces(StatusCodes.Status404NotFound)
+    .WithOpenApi();
+
+static Guid GetUserId(ClaimsPrincipal user, IConfiguration cfg)
+{
+    var claim = user.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+    if (Guid.TryParse(claim, out var id))
+    {
+        return id;
+    }
+    var fallback = cfg.GetSection("User").Get<UserSettings>()?.FallbackUserId ?? string.Empty;
+    if (Guid.TryParse(fallback, out id))
+    {
+        return id;
+    }
+    using var md5 = System.Security.Cryptography.MD5.Create();
+    var hash = md5.ComputeHash(System.Text.Encoding.UTF8.GetBytes(fallback));
+    return new Guid(hash);
+}
 
 app.Run();

--- a/src/HolaBebe.Api/UserSettings.cs
+++ b/src/HolaBebe.Api/UserSettings.cs
@@ -1,0 +1,6 @@
+namespace HolaBebe.Api;
+
+public sealed class UserSettings
+{
+    public string FallbackUserId { get; set; } = string.Empty;
+}

--- a/src/HolaBebe.Api/appsettings.Development.json
+++ b/src/HolaBebe.Api/appsettings.Development.json
@@ -7,5 +7,8 @@
   },
   "Cosmos": {
     "ConnectionString": "AccountEndpoint=https://holabebe.documents.azure.com:443/;AccountKey=XXX;"
+  },
+  "User": {
+    "FallbackUserId": "HTIPUNCH07Qg9WkJqVonQmUUaZD2"
   }
 }

--- a/src/HolaBebe.Api/appsettings.json
+++ b/src/HolaBebe.Api/appsettings.json
@@ -8,5 +8,8 @@
   "AllowedHosts": "*",
   "Cosmos": {
     "ConnectionString": "AccountEndpoint=https://holabebe.documents.azure.com:443/;AccountKey=XXX;"
+  },
+  "User": {
+    "FallbackUserId": "HTIPUNCH07Qg9WkJqVonQmUUaZD2"
   }
 }

--- a/src/HolaBebe.Application/Mapping/MappingConfig.cs
+++ b/src/HolaBebe.Application/Mapping/MappingConfig.cs
@@ -9,6 +9,9 @@ public static class MappingConfig
     public static void Register()
     {
         TypeAdapterConfig<UserProfile, UserProfileDto>.NewConfig();
+        TypeAdapterConfig<UserProfileDto, UserProfile>.NewConfig();
+
         TypeAdapterConfig<Pregnancy, PregnancyDto>.NewConfig();
+        TypeAdapterConfig<PregnancyDto, Pregnancy>.NewConfig();
     }
 }

--- a/src/HolaBebe.Application/ServiceCollectionExtensions.cs
+++ b/src/HolaBebe.Application/ServiceCollectionExtensions.cs
@@ -1,0 +1,14 @@
+using HolaBebe.Application.Services;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace HolaBebe.Application;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddApplication(this IServiceCollection services)
+    {
+        services.AddScoped<IProfileService, ProfileService>();
+        services.AddScoped<IPregnancyService, PregnancyService>();
+        return services;
+    }
+}

--- a/src/HolaBebe.Application/Services/IPregnancyService.cs
+++ b/src/HolaBebe.Application/Services/IPregnancyService.cs
@@ -1,0 +1,9 @@
+namespace HolaBebe.Application.Services;
+
+using HolaBebe.Application.Dtos;
+
+public interface IPregnancyService
+{
+    Task<PregnancyDto> CreatePregnancyAsync(PregnancyDto dto, Guid userId, CancellationToken ct);
+    Task<PregnancyDto?> GetCurrentPregnancyAsync(Guid userId, CancellationToken ct);
+}

--- a/src/HolaBebe.Application/Services/IProfileService.cs
+++ b/src/HolaBebe.Application/Services/IProfileService.cs
@@ -1,0 +1,9 @@
+namespace HolaBebe.Application.Services;
+
+using HolaBebe.Application.Dtos;
+
+public interface IProfileService
+{
+    Task<UserProfileDto?> GetProfileAsync(Guid userId, CancellationToken ct);
+    Task<UserProfileDto> UpsertProfileAsync(UserProfileDto dto, Guid userId, CancellationToken ct);
+}

--- a/src/HolaBebe.Application/Services/PregnancyService.cs
+++ b/src/HolaBebe.Application/Services/PregnancyService.cs
@@ -1,0 +1,31 @@
+using HolaBebe.Application.Dtos;
+using HolaBebe.Application.Interfaces;
+using HolaBebe.Domain.Entities;
+using Mapster;
+
+namespace HolaBebe.Application.Services;
+
+public sealed class PregnancyService : IPregnancyService
+{
+    private readonly IUnitOfWork _uow;
+
+    public PregnancyService(IUnitOfWork uow) => _uow = uow;
+
+    public async Task<PregnancyDto> CreatePregnancyAsync(PregnancyDto dto, Guid userId, CancellationToken ct)
+    {
+        var entity = dto.Adapt<Pregnancy>();
+        entity.UserId = userId;
+        await _uow.Pregnancies.AddAsync(entity, ct);
+        await _uow.SaveChangesAsync(ct);
+        return entity.Adapt<PregnancyDto>();
+    }
+
+    public async Task<PregnancyDto?> GetCurrentPregnancyAsync(Guid userId, CancellationToken ct)
+    {
+        await foreach (var entity in _uow.Pregnancies.GetAsync(p => p.UserId == userId && p.Current, ct))
+        {
+            return entity.Adapt<PregnancyDto>();
+        }
+        return null;
+    }
+}

--- a/src/HolaBebe.Application/Services/ProfileService.cs
+++ b/src/HolaBebe.Application/Services/ProfileService.cs
@@ -1,0 +1,55 @@
+using HolaBebe.Application.Dtos;
+using HolaBebe.Application.Interfaces;
+using HolaBebe.Domain.Entities;
+using Mapster;
+
+namespace HolaBebe.Application.Services;
+
+public sealed class ProfileService : IProfileService
+{
+    private readonly IUnitOfWork _uow;
+
+    public ProfileService(IUnitOfWork uow) => _uow = uow;
+
+    public async Task<UserProfileDto?> GetProfileAsync(Guid userId, CancellationToken ct)
+    {
+        await foreach (var entity in _uow.UserProfiles.GetAsync(p => p.UserId == userId, ct))
+        {
+            return entity.Adapt<UserProfileDto>();
+        }
+        return null;
+    }
+
+    public async Task<UserProfileDto> UpsertProfileAsync(UserProfileDto dto, Guid userId, CancellationToken ct)
+    {
+        UserProfile? entity = null;
+        await foreach (var p in _uow.UserProfiles.GetAsync(p => p.UserId == userId, ct))
+        {
+            entity = p;
+            break;
+        }
+
+        if (entity is null)
+        {
+            entity = dto.Adapt<UserProfile>();
+            entity.UserId = userId;
+            await _uow.UserProfiles.AddAsync(entity, ct);
+        }
+        else
+        {
+            entity.DisplayName = dto.DisplayName;
+            entity.PhotoUrl = dto.PhotoUrl;
+            entity.BirthDate = dto.BirthDate;
+            entity.Gender = dto.Gender;
+            entity.Country = dto.Country;
+            entity.Phone = dto.Phone;
+            entity.Goals = dto.Goals;
+            entity.Interests = dto.Interests;
+            entity.Touch();
+            await _uow.UserProfiles.UpdateAsync(entity, ct);
+        }
+
+        await _uow.SaveChangesAsync(ct);
+        return entity.Adapt<UserProfileDto>();
+    }
+}


### PR DESCRIPTION
## Summary
- implement application services for profile and pregnancy management
- expose service registration via `AddApplication`
- add user fallback ID configuration and retrieval helper
- create minimal API endpoints for profile and pregnancy
- expand Mapster mappings

## Testing
- `dotnet format --verify-no-changes` *(fails: command not found)*
- `dotnet build -c Release` *(fails: command not found)*
- `dotnet test /p:CollectCoverage=true` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dce9c95f883338cf353c8075e03ec