### PR TITLE
Add domain models and DTOs

### DIFF
--- a/src/HolaBebe.Application/Dtos/ArticleDto.cs
+++ b/src/HolaBebe.Application/Dtos/ArticleDto.cs
@@ -1,0 +1,10 @@
+namespace HolaBebe.Application.Dtos;
+
+public sealed class ArticleDto
+{
+    public string Title { get; init; } = string.Empty;
+    public string HtmlContent { get; init; } = string.Empty;
+    public ICollection<string> Tags { get; init; } = Array.Empty<string>();
+    public string Author { get; init; } = string.Empty;
+    public DateTime PublishedAt { get; init; }
+}

--- a/src/HolaBebe.Application/Dtos/ArticleListDto.cs
+++ b/src/HolaBebe.Application/Dtos/ArticleListDto.cs
@@ -1,0 +1,10 @@
+namespace HolaBebe.Application.Dtos;
+
+public sealed class ArticleListDto
+{
+    public string Slug { get; init; } = string.Empty;
+    public string Title { get; init; } = string.Empty;
+    public string Excerpt { get; init; } = string.Empty;
+    public string? CoverImageUrl { get; init; }
+    public DateTime PublishedAt { get; init; }
+}

--- a/src/HolaBebe.Application/Dtos/CalendarEventCreateDto.cs
+++ b/src/HolaBebe.Application/Dtos/CalendarEventCreateDto.cs
@@ -1,0 +1,15 @@
+using HolaBebe.Domain;
+
+namespace HolaBebe.Application.Dtos;
+
+public sealed class CalendarEventCreateDto
+{
+    public string Title { get; init; } = string.Empty;
+    public string? Description { get; init; }
+    public DateTime StartDateTime { get; init; }
+    public DateTime? EndDateTime { get; init; }
+    public CalendarType Type { get; init; }
+    public string? Color { get; init; }
+    public Guid? PregnancyId { get; init; }
+    public string? Location { get; init; }
+}

--- a/src/HolaBebe.Application/Dtos/CalendarEventDto.cs
+++ b/src/HolaBebe.Application/Dtos/CalendarEventDto.cs
@@ -1,0 +1,12 @@
+using HolaBebe.Domain;
+
+namespace HolaBebe.Application.Dtos;
+
+public sealed class CalendarEventDto
+{
+    public Guid Id { get; init; }
+    public string Title { get; init; } = string.Empty;
+    public DateTime StartDateTime { get; init; }
+    public CalendarType Type { get; init; }
+    public string? Color { get; init; }
+}

--- a/src/HolaBebe.Application/Dtos/FruitSizeDto.cs
+++ b/src/HolaBebe.Application/Dtos/FruitSizeDto.cs
@@ -1,0 +1,10 @@
+namespace HolaBebe.Application.Dtos;
+
+public sealed class FruitSizeDto
+{
+    public int Week { get; init; }
+    public string FruitName { get; init; } = string.Empty;
+    public double LengthMm { get; init; }
+    public double WeightG { get; init; }
+    public string? ImageUrl { get; init; }
+}

--- a/src/HolaBebe.Application/Dtos/PregnancyCreateDto.cs
+++ b/src/HolaBebe.Application/Dtos/PregnancyCreateDto.cs
@@ -1,0 +1,9 @@
+namespace HolaBebe.Application.Dtos;
+
+public sealed class PregnancyCreateDto
+{
+    public int? GestationalAgeDays { get; init; }
+    public DateTime? ConceptionDate { get; init; }
+    public DateTime? DueDate { get; init; }
+    public DateTime? LastMenstruationDate { get; init; }
+}

--- a/src/HolaBebe.Application/Dtos/PregnancyDto.cs
+++ b/src/HolaBebe.Application/Dtos/PregnancyDto.cs
@@ -5,11 +5,7 @@ namespace HolaBebe.Application.Dtos;
 public sealed class PregnancyDto
 {
     public Guid Id { get; init; }
-    public bool Current { get; init; }
-    public int GestationalAgeDays { get; init; }
-    public DateTime? ConceptionDate { get; init; }
-    public DateTime? DueDate { get; init; }
-    public DateTime? LastMenstruationDate { get; init; }
-    public PregnancyEstimationMethod EstimationMethod { get; init; }
     public int WeekNumber { get; init; }
+    public DateTime? DueDate { get; init; }
+    public bool Current { get; init; }
 }

--- a/src/HolaBebe.Application/Dtos/TutorialSlideDto.cs
+++ b/src/HolaBebe.Application/Dtos/TutorialSlideDto.cs
@@ -1,0 +1,9 @@
+namespace HolaBebe.Application.Dtos;
+
+public sealed class TutorialSlideDto
+{
+    public int Order { get; init; }
+    public string Title { get; init; } = string.Empty;
+    public string Subtitle { get; init; } = string.Empty;
+    public string ImageUrl { get; init; } = string.Empty;
+}

--- a/src/HolaBebe.Application/Dtos/UserProfileDto.cs
+++ b/src/HolaBebe.Application/Dtos/UserProfileDto.cs
@@ -4,13 +4,12 @@ namespace HolaBebe.Application.Dtos;
 
 public sealed class UserProfileDto
 {
-    public Guid Id { get; init; }
     public string DisplayName { get; init; } = string.Empty;
     public string? PhotoUrl { get; init; }
     public DateTime BirthDate { get; init; }
     public Gender Gender { get; init; }
     public string? Country { get; init; }
     public string? Phone { get; init; }
-    public string? Goals { get; init; }
-    public string? Interests { get; init; }
+    public ICollection<GoalType> Goals { get; init; } = Array.Empty<GoalType>();
+    public ICollection<InterestType> Interests { get; init; } = Array.Empty<InterestType>();
 }

--- a/src/HolaBebe.Application/Dtos/WeeklySummaryDto.cs
+++ b/src/HolaBebe.Application/Dtos/WeeklySummaryDto.cs
@@ -1,0 +1,11 @@
+namespace HolaBebe.Application.Dtos;
+
+public sealed class WeeklySummaryDto
+{
+    public int Week { get; init; }
+    public string Baby { get; init; } = string.Empty;
+    public string Mom { get; init; } = string.Empty;
+    public string Nutrition { get; init; } = string.Empty;
+    public string Tips { get; init; } = string.Empty;
+    public FruitSizeDto? FruitSize { get; init; }
+}

--- a/src/HolaBebe.Application/Mapping/MappingConfig.cs
+++ b/src/HolaBebe.Application/Mapping/MappingConfig.cs
@@ -12,6 +12,16 @@ public static class MappingConfig
         TypeAdapterConfig<UserProfileDto, UserProfile>.NewConfig();
 
         TypeAdapterConfig<Pregnancy, PregnancyDto>.NewConfig();
-        TypeAdapterConfig<PregnancyDto, Pregnancy>.NewConfig();
+        TypeAdapterConfig<PregnancyCreateDto, Pregnancy>.NewConfig();
+
+        TypeAdapterConfig<FruitSizeCatalog, FruitSizeDto>.NewConfig();
+
+        TypeAdapterConfig<CalendarEvent, CalendarEventDto>.NewConfig();
+        TypeAdapterConfig<CalendarEventCreateDto, CalendarEvent>.NewConfig();
+
+        TypeAdapterConfig<Article, ArticleListDto>.NewConfig();
+        TypeAdapterConfig<Article, ArticleDto>.NewConfig();
+
+        TypeAdapterConfig<TutorialSlide, TutorialSlideDto>.NewConfig();
     }
 }

--- a/src/HolaBebe.Domain/Entities/Article.cs
+++ b/src/HolaBebe.Domain/Entities/Article.cs
@@ -1,0 +1,15 @@
+using HolaBebe.Domain;
+
+namespace HolaBebe.Domain.Entities;
+
+public sealed class Article : AuditableEntity
+{
+    public string Slug { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public string Excerpt { get; set; } = string.Empty;
+    public string HtmlContent { get; set; } = string.Empty;
+    public string? CoverImageUrl { get; set; }
+    public List<string> Tags { get; set; } = new();
+    public DateTime PublishedAt { get; set; }
+    public Guid AuthorId { get; set; }
+}

--- a/src/HolaBebe.Domain/Entities/CalendarEvent.cs
+++ b/src/HolaBebe.Domain/Entities/CalendarEvent.cs
@@ -1,0 +1,15 @@
+using HolaBebe.Domain;
+
+namespace HolaBebe.Domain.Entities;
+
+public sealed class CalendarEvent : AuditableEntity
+{
+    public string Title { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public DateTime StartDateTime { get; set; }
+    public DateTime? EndDateTime { get; set; }
+    public CalendarType Type { get; set; }
+    public string? Color { get; set; }
+    public Guid? PregnancyId { get; set; }
+    public string? Location { get; set; }
+}

--- a/src/HolaBebe.Domain/Entities/FruitSizeCatalog.cs
+++ b/src/HolaBebe.Domain/Entities/FruitSizeCatalog.cs
@@ -1,0 +1,12 @@
+using HolaBebe.Domain;
+
+namespace HolaBebe.Domain.Entities;
+
+public sealed class FruitSizeCatalog : AuditableEntity
+{
+    public int Week { get; set; }
+    public string FruitName { get; set; } = string.Empty;
+    public double LengthMm { get; set; }
+    public double WeightG { get; set; }
+    public string? ImageUrl { get; set; }
+}

--- a/src/HolaBebe.Domain/Entities/Pregnancy.cs
+++ b/src/HolaBebe.Domain/Entities/Pregnancy.cs
@@ -9,7 +9,7 @@ public sealed class Pregnancy : AuditableEntity
     public DateTime? ConceptionDate { get; set; }
     public DateTime? DueDate { get; set; }
     public DateTime? LastMenstruationDate { get; set; }
-    public PregnancyEstimationMethod EstimationMethod { get; set; }
+    public EstimationMethod EstimationMethod { get; set; }
 
     public int WeekNumber => Math.Clamp((int)Math.Floor(GestationalAgeDays / 7d) + 1, 1, 42);
 }

--- a/src/HolaBebe.Domain/Entities/StoreItem.cs
+++ b/src/HolaBebe.Domain/Entities/StoreItem.cs
@@ -1,0 +1,13 @@
+using HolaBebe.Domain;
+
+namespace HolaBebe.Domain.Entities;
+
+public sealed class StoreItem : AuditableEntity
+{
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public string PriceCurrency { get; set; } = string.Empty;
+    public decimal PriceAmount { get; set; }
+    public string ImageUrl { get; set; } = string.Empty;
+    public bool IsActive { get; set; }
+}

--- a/src/HolaBebe.Domain/Entities/TutorialSlide.cs
+++ b/src/HolaBebe.Domain/Entities/TutorialSlide.cs
@@ -1,0 +1,11 @@
+using HolaBebe.Domain;
+
+namespace HolaBebe.Domain.Entities;
+
+public sealed class TutorialSlide : AuditableEntity
+{
+    public int Order { get; set; }
+    public string Title { get; set; } = string.Empty;
+    public string Subtitle { get; set; } = string.Empty;
+    public string ImageUrl { get; set; } = string.Empty;
+}

--- a/src/HolaBebe.Domain/Entities/UserProfile.cs
+++ b/src/HolaBebe.Domain/Entities/UserProfile.cs
@@ -10,6 +10,6 @@ public sealed class UserProfile : AuditableEntity
     public Gender Gender { get; set; }
     public string? Country { get; set; }
     public string? Phone { get; set; }
-    public string? Goals { get; set; }
-    public string? Interests { get; set; }
+    public List<GoalType> Goals { get; set; } = new();
+    public List<InterestType> Interests { get; set; } = new();
 }

--- a/src/HolaBebe.Domain/Entities/WeeklyContent.cs
+++ b/src/HolaBebe.Domain/Entities/WeeklyContent.cs
@@ -1,0 +1,14 @@
+using HolaBebe.Domain;
+
+namespace HolaBebe.Domain.Entities;
+
+public sealed class WeeklyContent : AuditableEntity
+{
+    public int Week { get; set; }
+    public WeeklyCategory Category { get; set; }
+    public string Title { get; set; } = string.Empty;
+    public string HtmlContent { get; set; } = string.Empty;
+    public string? VideoUrl { get; set; }
+    public string Author { get; set; } = string.Empty;
+    public string Locale { get; set; } = string.Empty;
+}

--- a/src/HolaBebe.Domain/Enums.cs
+++ b/src/HolaBebe.Domain/Enums.cs
@@ -4,13 +4,50 @@ public enum Gender
 {
     Unknown = 0,
     Female = 1,
-    Male = 2
+    Male = 2,
+    Other = 3
 }
 
-public enum PregnancyEstimationMethod
+public enum GoalType
 {
     Unknown = 0,
-    LastMenstruation = 1,
-    Ultrasound = 2,
-    ConceptionDate = 3
+    Conceive = 1,
+    Pregnancy = 2,
+    ChildDevelopment = 3
+}
+
+public enum InterestType
+{
+    Unknown = 0,
+    Lifestyle = 1,
+    Nutrition = 2,
+    Sleep = 3,
+    Health = 4,
+    Delivery = 5
+}
+
+public enum EstimationMethod
+{
+    Unknown = 0,
+    Ga = 1,
+    Conception = 2,
+    Due = 3,
+    Lmp = 4
+}
+
+public enum CalendarType
+{
+    Unknown = 0,
+    Appointment = 1,
+    Milestone = 2,
+    Reminder = 3
+}
+
+public enum WeeklyCategory
+{
+    Unknown = 0,
+    Baby = 1,
+    Mom = 2,
+    Nutrition = 3,
+    Tips = 4
 }


### PR DESCRIPTION
## Summary
- expand domain enumerations with goal, interest, estimation and calendar types
- model new entities: FruitSizeCatalog, WeeklyContent, Article, CalendarEvent, TutorialSlide, StoreItem
- adjust existing entities to use new enums
- create DTOs for fruits, pregnancy creation, weekly summaries, calendar events, articles and tutorial slides
- update mapping configuration

## Testing
- `dotnet format --verify-no-changes` *(fails: command not found)*
- `dotnet build -c Release` *(fails: command not found)*
- `dotnet test /p:CollectCoverage=true` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dd4672688833393ecc8ba10b1b5de