### PR TITLE
Implement profile CRUD endpoints

### DIFF
--- a/src/HolaBebe.Application/Services/IProfileService.cs
+++ b/src/HolaBebe.Application/Services/IProfileService.cs
@@ -5,5 +5,6 @@ using HolaBebe.Application.Dtos;
 public interface IProfileService
 {
     Task<UserProfileDto?> GetProfileAsync(Guid userId, CancellationToken ct);
-    Task<UserProfileDto> UpsertProfileAsync(UserProfileDto dto, Guid userId, CancellationToken ct);
+    Task<UserProfileDto> CreateProfileAsync(UserProfileDto dto, Guid userId, CancellationToken ct);
+    Task<UserProfileDto?> UpdateProfileAsync(UserProfileDto dto, Guid userId, CancellationToken ct);
 }

--- a/src/HolaBebe.Application/Services/ProfileService.cs
+++ b/src/HolaBebe.Application/Services/ProfileService.cs
@@ -20,7 +20,21 @@ public sealed class ProfileService : IProfileService
         return null;
     }
 
-    public async Task<UserProfileDto> UpsertProfileAsync(UserProfileDto dto, Guid userId, CancellationToken ct)
+    public async Task<UserProfileDto> CreateProfileAsync(UserProfileDto dto, Guid userId, CancellationToken ct)
+    {
+        await foreach (var _ in _uow.UserProfiles.GetAsync(p => p.UserId == userId, ct))
+        {
+            throw new InvalidOperationException("Profile already exists");
+        }
+
+        var entity = dto.Adapt<UserProfile>();
+        entity.UserId = userId;
+        await _uow.UserProfiles.AddAsync(entity, ct);
+        await _uow.SaveChangesAsync(ct);
+        return entity.Adapt<UserProfileDto>();
+    }
+
+    public async Task<UserProfileDto?> UpdateProfileAsync(UserProfileDto dto, Guid userId, CancellationToken ct)
     {
         UserProfile? entity = null;
         await foreach (var p in _uow.UserProfiles.GetAsync(p => p.UserId == userId, ct))
@@ -31,24 +45,19 @@ public sealed class ProfileService : IProfileService
 
         if (entity is null)
         {
-            entity = dto.Adapt<UserProfile>();
-            entity.UserId = userId;
-            await _uow.UserProfiles.AddAsync(entity, ct);
-        }
-        else
-        {
-            entity.DisplayName = dto.DisplayName;
-            entity.PhotoUrl = dto.PhotoUrl;
-            entity.BirthDate = dto.BirthDate;
-            entity.Gender = dto.Gender;
-            entity.Country = dto.Country;
-            entity.Phone = dto.Phone;
-            entity.Goals = dto.Goals;
-            entity.Interests = dto.Interests;
-            entity.Touch();
-            await _uow.UserProfiles.UpdateAsync(entity, ct);
+            return null;
         }
 
+        entity.DisplayName = dto.DisplayName;
+        entity.PhotoUrl = dto.PhotoUrl;
+        entity.BirthDate = dto.BirthDate;
+        entity.Gender = dto.Gender;
+        entity.Country = dto.Country;
+        entity.Phone = dto.Phone;
+        entity.Goals = dto.Goals.ToList();
+        entity.Interests = dto.Interests.ToList();
+        entity.Touch();
+        await _uow.UserProfiles.UpdateAsync(entity, ct);
         await _uow.SaveChangesAsync(ct);
         return entity.Adapt<UserProfileDto>();
     }


### PR DESCRIPTION
## Summary
- split user profile service into Create and Update operations
- add POST & PUT endpoints for `/me/profile`
- implement creation and update logic

## Testing
- `dotnet format --verify-no-changes` *(fails: command not found)*
- `dotnet build -c Release` *(fails: command not found)*
- `dotnet test /p:CollectCoverage=true` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684df22e77748333a97ba2497cf6e9ba