### PR TITLE
Implement pregnancy management endpoints

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,173 @@
+openapi: 3.0.1
+info:
+  title: Hola Bebe API
+  version: '1.0'
+paths:
+  /pregnancies:
+    post:
+      summary: Create pregnancy record
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PregnancyCreateDto'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PregnancyDto'
+        '409':
+          description: Conflict
+  /pregnancies/current:
+    get:
+      summary: Get current pregnancy
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PregnancyDto'
+        '404':
+          description: Not Found
+  /pregnancies/{id}:
+    patch:
+      summary: Update pregnancy record
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+          required: true
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PregnancyUpdateDto'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PregnancyDto'
+        '404':
+          description: Not Found
+  /pregnancies/{id}/fruit-size:
+    get:
+      summary: Get baby size as fruit
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FruitSizeDto'
+        '404':
+          description: Not Found
+  /pregnancies/{id}/week/{n}:
+    get:
+      summary: Get weekly content summary
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+          required: true
+        - in: path
+          name: n
+          schema:
+            type: integer
+          required: true
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WeeklySummaryDto'
+        '404':
+          description: Not Found
+components:
+  schemas:
+    PregnancyCreateDto:
+      type: object
+      properties:
+        gestationalAgeDays:
+          type: integer
+        conceptionDate:
+          type: string
+          format: date-time
+        dueDate:
+          type: string
+          format: date-time
+        lastMenstruationDate:
+          type: string
+          format: date-time
+    PregnancyUpdateDto:
+      type: object
+      properties:
+        gestationalAgeDays:
+          type: integer
+        conceptionDate:
+          type: string
+          format: date-time
+        dueDate:
+          type: string
+          format: date-time
+        lastMenstruationDate:
+          type: string
+          format: date-time
+        current:
+          type: boolean
+    PregnancyDto:
+      type: object
+      properties:
+        id:
+          type: string
+        weekNumber:
+          type: integer
+        dueDate:
+          type: string
+          format: date-time
+        current:
+          type: boolean
+    FruitSizeDto:
+      type: object
+      properties:
+        week:
+          type: integer
+        fruitName:
+          type: string
+        lengthMm:
+          type: number
+        weightG:
+          type: number
+        imageUrl:
+          type: string
+    WeeklySummaryDto:
+      type: object
+      properties:
+        week:
+          type: integer
+        baby:
+          type: string
+        mom:
+          type: string
+        nutrition:
+          type: string
+        tips:
+          type: string
+        fruitSize:
+          $ref: '#/components/schemas/FruitSizeDto'
+

--- a/src/HolaBebe.Application/Dtos/PregnancyUpdateDto.cs
+++ b/src/HolaBebe.Application/Dtos/PregnancyUpdateDto.cs
@@ -1,0 +1,10 @@
+namespace HolaBebe.Application.Dtos;
+
+public sealed class PregnancyUpdateDto
+{
+    public int? GestationalAgeDays { get; init; }
+    public DateTime? ConceptionDate { get; init; }
+    public DateTime? DueDate { get; init; }
+    public DateTime? LastMenstruationDate { get; init; }
+    public bool? Current { get; init; }
+}

--- a/src/HolaBebe.Application/Interfaces/IUnitOfWork.cs
+++ b/src/HolaBebe.Application/Interfaces/IUnitOfWork.cs
@@ -6,5 +6,7 @@ public interface IUnitOfWork
 {
     IGenericRepository<UserProfile> UserProfiles { get; }
     IGenericRepository<Pregnancy> Pregnancies { get; }
+    IGenericRepository<FruitSizeCatalog> FruitSizes { get; }
+    IGenericRepository<WeeklyContent> WeeklyContents { get; }
     Task<int> SaveChangesAsync(CancellationToken ct);
 }

--- a/src/HolaBebe.Application/Services/IPregnancyService.cs
+++ b/src/HolaBebe.Application/Services/IPregnancyService.cs
@@ -4,6 +4,9 @@ using HolaBebe.Application.Dtos;
 
 public interface IPregnancyService
 {
-    Task<PregnancyDto> CreatePregnancyAsync(PregnancyDto dto, Guid userId, CancellationToken ct);
+    Task<PregnancyDto> CreatePregnancyAsync(PregnancyCreateDto dto, Guid userId, CancellationToken ct);
     Task<PregnancyDto?> GetCurrentPregnancyAsync(Guid userId, CancellationToken ct);
+    Task<PregnancyDto?> UpdatePregnancyAsync(Guid id, PregnancyUpdateDto dto, Guid userId, CancellationToken ct);
+    Task<FruitSizeDto?> GetFruitSizeAsync(Guid id, Guid userId, CancellationToken ct);
+    Task<WeeklySummaryDto?> GetWeeklySummaryAsync(Guid id, int week, Guid userId, CancellationToken ct);
 }

--- a/src/HolaBebe.Application/Services/PregnancyService.cs
+++ b/src/HolaBebe.Application/Services/PregnancyService.cs
@@ -1,6 +1,7 @@
 using HolaBebe.Application.Dtos;
 using HolaBebe.Application.Interfaces;
 using HolaBebe.Domain.Entities;
+using HolaBebe.Domain;
 using Mapster;
 
 namespace HolaBebe.Application.Services;
@@ -11,10 +12,26 @@ public sealed class PregnancyService : IPregnancyService
 
     public PregnancyService(IUnitOfWork uow) => _uow = uow;
 
-    public async Task<PregnancyDto> CreatePregnancyAsync(PregnancyDto dto, Guid userId, CancellationToken ct)
+    public async Task<PregnancyDto> CreatePregnancyAsync(PregnancyCreateDto dto, Guid userId, CancellationToken ct)
     {
-        var entity = dto.Adapt<Pregnancy>();
-        entity.UserId = userId;
+        await foreach (var _ in _uow.Pregnancies.GetAsync(p => p.UserId == userId && p.Current, ct))
+        {
+            throw new InvalidOperationException("Pregnancy already exists");
+        }
+
+        var (days, method) = ComputeGestationalAge(dto);
+
+        var entity = new Pregnancy
+        {
+            UserId = userId,
+            Current = true,
+            GestationalAgeDays = days,
+            ConceptionDate = dto.ConceptionDate,
+            DueDate = dto.DueDate,
+            LastMenstruationDate = dto.LastMenstruationDate,
+            EstimationMethod = method
+        };
+
         await _uow.Pregnancies.AddAsync(entity, ct);
         await _uow.SaveChangesAsync(ct);
         return entity.Adapt<PregnancyDto>();
@@ -27,5 +44,134 @@ public sealed class PregnancyService : IPregnancyService
             return entity.Adapt<PregnancyDto>();
         }
         return null;
+    }
+
+    public async Task<PregnancyDto?> UpdatePregnancyAsync(Guid id, PregnancyUpdateDto dto, Guid userId, CancellationToken ct)
+    {
+        var entity = await _uow.Pregnancies.GetByIdAsync(id, ct);
+        if (entity is null || entity.UserId != userId)
+        {
+            return null;
+        }
+
+        if (dto.Current.HasValue)
+        {
+            entity.Current = dto.Current.Value;
+        }
+
+        if (dto.GestationalAgeDays.HasValue)
+        {
+            entity.GestationalAgeDays = dto.GestationalAgeDays.Value;
+            entity.EstimationMethod = EstimationMethod.Ga;
+        }
+        else if (dto.ConceptionDate.HasValue)
+        {
+            entity.ConceptionDate = dto.ConceptionDate;
+            entity.GestationalAgeDays = (int)(DateTime.UtcNow.Date - dto.ConceptionDate.Value.Date).TotalDays;
+            entity.EstimationMethod = EstimationMethod.Conception;
+        }
+        else if (dto.LastMenstruationDate.HasValue)
+        {
+            entity.LastMenstruationDate = dto.LastMenstruationDate;
+            entity.GestationalAgeDays = (int)(DateTime.UtcNow.Date - dto.LastMenstruationDate.Value.Date).TotalDays;
+            entity.EstimationMethod = EstimationMethod.Lmp;
+        }
+        else if (dto.DueDate.HasValue)
+        {
+            entity.DueDate = dto.DueDate;
+            entity.GestationalAgeDays = 280 - (int)(dto.DueDate.Value.Date - DateTime.UtcNow.Date).TotalDays;
+            entity.EstimationMethod = EstimationMethod.Due;
+        }
+
+        entity.Touch();
+        await _uow.Pregnancies.UpdateAsync(entity, ct);
+        await _uow.SaveChangesAsync(ct);
+        return entity.Adapt<PregnancyDto>();
+    }
+
+    public async Task<FruitSizeDto?> GetFruitSizeAsync(Guid id, Guid userId, CancellationToken ct)
+    {
+        var preg = await _uow.Pregnancies.GetByIdAsync(id, ct);
+        if (preg is null || preg.UserId != userId)
+        {
+            return null;
+        }
+
+        await foreach (var fs in _uow.FruitSizes.GetAsync(f => f.Week == preg.WeekNumber, ct))
+        {
+            return fs.Adapt<FruitSizeDto>();
+        }
+
+        return null;
+    }
+
+    public async Task<WeeklySummaryDto?> GetWeeklySummaryAsync(Guid id, int week, Guid userId, CancellationToken ct)
+    {
+        if (week < 1 || week > 42)
+        {
+            return null;
+        }
+
+        var preg = await _uow.Pregnancies.GetByIdAsync(id, ct);
+        if (preg is null || preg.UserId != userId)
+        {
+            return null;
+        }
+
+        var summary = new WeeklySummaryDto { Week = week };
+
+        await foreach (var content in _uow.WeeklyContents.GetAsync(c => c.Week == week, ct))
+        {
+            switch (content.Category)
+            {
+                case WeeklyCategory.Baby:
+                    summary.Baby = content.HtmlContent;
+                    break;
+                case WeeklyCategory.Mom:
+                    summary.Mom = content.HtmlContent;
+                    break;
+                case WeeklyCategory.Nutrition:
+                    summary.Nutrition = content.HtmlContent;
+                    break;
+                case WeeklyCategory.Tips:
+                    summary.Tips = content.HtmlContent;
+                    break;
+            }
+        }
+
+        await foreach (var fs in _uow.FruitSizes.GetAsync(f => f.Week == week, ct))
+        {
+            summary.FruitSize = fs.Adapt<FruitSizeDto>();
+            break;
+        }
+
+        return summary;
+    }
+
+    private static (int days, EstimationMethod method) ComputeGestationalAge(PregnancyCreateDto dto)
+    {
+        var today = DateTime.UtcNow.Date;
+
+        if (dto.GestationalAgeDays.HasValue)
+        {
+            return (dto.GestationalAgeDays.Value, EstimationMethod.Ga);
+        }
+
+        if (dto.ConceptionDate.HasValue)
+        {
+            return ((int)(today - dto.ConceptionDate.Value.Date).TotalDays, EstimationMethod.Conception);
+        }
+
+        if (dto.LastMenstruationDate.HasValue)
+        {
+            return ((int)(today - dto.LastMenstruationDate.Value.Date).TotalDays, EstimationMethod.Lmp);
+        }
+
+        if (dto.DueDate.HasValue)
+        {
+            return (280 - (int)(dto.DueDate.Value.Date - today).TotalDays, EstimationMethod.Due);
+        }
+
+        return (0, EstimationMethod.Unknown);
     }
 }

--- a/src/HolaBebe.Infrastructure/Data/CosmosDbUnitOfWork.cs
+++ b/src/HolaBebe.Infrastructure/Data/CosmosDbUnitOfWork.cs
@@ -13,6 +13,8 @@ public sealed class CosmosDbUnitOfWork : IUnitOfWork, IDisposable
 
     public IGenericRepository<UserProfile> UserProfiles { get; }
     public IGenericRepository<Pregnancy> Pregnancies { get; }
+    public IGenericRepository<FruitSizeCatalog> FruitSizes { get; }
+    public IGenericRepository<WeeklyContent> WeeklyContents { get; }
 
     public CosmosDbUnitOfWork(CosmosClient client, IOptions<CosmosSettings> options)
     {
@@ -20,6 +22,8 @@ public sealed class CosmosDbUnitOfWork : IUnitOfWork, IDisposable
         _database = _client.CreateDatabaseIfNotExistsAsync(options.Value.DatabaseId).GetAwaiter().GetResult();
         UserProfiles = new CosmosDbRepository<UserProfile>(_database.CreateContainerIfNotExistsAsync("UserProfiles", "/id").GetAwaiter().GetResult());
         Pregnancies = new CosmosDbRepository<Pregnancy>(_database.CreateContainerIfNotExistsAsync("Pregnancies", "/id").GetAwaiter().GetResult());
+        FruitSizes = new CosmosDbRepository<FruitSizeCatalog>(_database.CreateContainerIfNotExistsAsync("FruitSizes", "/id").GetAwaiter().GetResult());
+        WeeklyContents = new CosmosDbRepository<WeeklyContent>(_database.CreateContainerIfNotExistsAsync("WeeklyContents", "/id").GetAwaiter().GetResult());
     }
 
     public Task<int> SaveChangesAsync(CancellationToken ct) => Task.FromResult(0);


### PR DESCRIPTION
## Summary
- add PregnancyUpdateDto DTO
- extend PregnancyService with update, fruit size and weekly summary logic
- expose new repos for fruit size and weekly content in UnitOfWork
- create minimal OpenAPI spec with pregnancy endpoints
- implement endpoints for update, fruit size and weekly summary

## Testing
- `dotnet format --verify-no-changes` *(fails: dotnet not found)*
- `dotnet build -c Release` *(fails: dotnet not found)*
- `dotnet test /p:CollectCoverage=true` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e1689587c8333a13cc9b04a0a2d6b