### PR TITLE
Add calendar event API

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -98,6 +98,102 @@ paths:
                 $ref: '#/components/schemas/WeeklySummaryDto'
         '404':
           description: Not Found
+  /calendar-events:
+    get:
+      summary: List calendar events
+      parameters:
+        - in: query
+          name: startDateFrom
+          schema:
+            type: string
+            format: date-time
+        - in: query
+          name: startDateTo
+          schema:
+            type: string
+            format: date-time
+        - in: query
+          name: type
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CalendarEventDto'
+    post:
+      summary: Create calendar event
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CalendarEventCreateDto'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CalendarEventDto'
+  /calendar-events/{id}:
+    get:
+      summary: Get calendar event
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CalendarEventDto'
+        '404':
+          description: Not Found
+    patch:
+      summary: Update calendar event
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+          required: true
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CalendarEventUpdateDto'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CalendarEventDto'
+        '404':
+          description: Not Found
+    delete:
+      summary: Delete calendar event
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+          required: true
+      responses:
+        '204':
+          description: No Content
+        '404':
+          description: Not Found
 components:
   schemas:
     PregnancyCreateDto:
@@ -170,4 +266,60 @@ components:
           type: string
         fruitSize:
           $ref: '#/components/schemas/FruitSizeDto'
+    CalendarEventCreateDto:
+      type: object
+      properties:
+        title:
+          type: string
+        description:
+          type: string
+        startDateTime:
+          type: string
+          format: date-time
+        endDateTime:
+          type: string
+          format: date-time
+        type:
+          type: integer
+        color:
+          type: string
+        pregnancyId:
+          type: string
+        location:
+          type: string
+    CalendarEventUpdateDto:
+      type: object
+      properties:
+        title:
+          type: string
+        description:
+          type: string
+        startDateTime:
+          type: string
+          format: date-time
+        endDateTime:
+          type: string
+          format: date-time
+        type:
+          type: integer
+        color:
+          type: string
+        pregnancyId:
+          type: string
+        location:
+          type: string
+    CalendarEventDto:
+      type: object
+      properties:
+        id:
+          type: string
+        title:
+          type: string
+        startDateTime:
+          type: string
+          format: date-time
+        type:
+          type: integer
+        color:
+          type: string
 

--- a/src/HolaBebe.Application/Dtos/CalendarEventUpdateDto.cs
+++ b/src/HolaBebe.Application/Dtos/CalendarEventUpdateDto.cs
@@ -1,0 +1,15 @@
+using HolaBebe.Domain;
+
+namespace HolaBebe.Application.Dtos;
+
+public sealed class CalendarEventUpdateDto
+{
+    public string? Title { get; init; }
+    public string? Description { get; init; }
+    public DateTime? StartDateTime { get; init; }
+    public DateTime? EndDateTime { get; init; }
+    public CalendarType? Type { get; init; }
+    public string? Color { get; init; }
+    public Guid? PregnancyId { get; init; }
+    public string? Location { get; init; }
+}

--- a/src/HolaBebe.Application/Interfaces/IUnitOfWork.cs
+++ b/src/HolaBebe.Application/Interfaces/IUnitOfWork.cs
@@ -8,5 +8,6 @@ public interface IUnitOfWork
     IGenericRepository<Pregnancy> Pregnancies { get; }
     IGenericRepository<FruitSizeCatalog> FruitSizes { get; }
     IGenericRepository<WeeklyContent> WeeklyContents { get; }
+    IGenericRepository<CalendarEvent> CalendarEvents { get; }
     Task<int> SaveChangesAsync(CancellationToken ct);
 }

--- a/src/HolaBebe.Application/ServiceCollectionExtensions.cs
+++ b/src/HolaBebe.Application/ServiceCollectionExtensions.cs
@@ -9,6 +9,7 @@ public static class ServiceCollectionExtensions
     {
         services.AddScoped<IProfileService, ProfileService>();
         services.AddScoped<IPregnancyService, PregnancyService>();
+        services.AddScoped<ICalendarService, CalendarService>();
         return services;
     }
 }

--- a/src/HolaBebe.Application/Services/CalendarService.cs
+++ b/src/HolaBebe.Application/Services/CalendarService.cs
@@ -1,0 +1,116 @@
+using HolaBebe.Application.Dtos;
+using HolaBebe.Application.Interfaces;
+using HolaBebe.Domain.Entities;
+using HolaBebe.Domain;
+using Mapster;
+using System.Runtime.CompilerServices;
+
+namespace HolaBebe.Application.Services;
+
+public sealed class CalendarService : ICalendarService
+{
+    private readonly IUnitOfWork _uow;
+
+    public CalendarService(IUnitOfWork uow) => _uow = uow;
+
+    public async Task<CalendarEventDto> CreateEventAsync(CalendarEventCreateDto dto, Guid userId, CancellationToken ct)
+    {
+        var entity = dto.Adapt<CalendarEvent>();
+        entity.UserId = userId;
+        await _uow.CalendarEvents.AddAsync(entity, ct);
+        await _uow.SaveChangesAsync(ct);
+        return entity.Adapt<CalendarEventDto>();
+    }
+
+    public async Task<bool> DeleteEventAsync(Guid id, Guid userId, CancellationToken ct)
+    {
+        var entity = await _uow.CalendarEvents.GetByIdAsync(id, ct);
+        if (entity is null || entity.UserId != userId)
+        {
+            return false;
+        }
+
+        await _uow.CalendarEvents.DeleteAsync(entity, ct);
+        await _uow.SaveChangesAsync(ct);
+        return true;
+    }
+
+    public async IAsyncEnumerable<CalendarEventDto> GetEventsAsync(
+        Guid userId,
+        DateTime? startFrom,
+        DateTime? startTo,
+        CalendarType? type,
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        await foreach (var entity in _uow.CalendarEvents.GetAsync(e =>
+            e.UserId == userId &&
+            (!startFrom.HasValue || e.StartDateTime >= startFrom.Value) &&
+            (!startTo.HasValue || e.StartDateTime <= startTo.Value) &&
+            (!type.HasValue || e.Type == type.Value), ct))
+        {
+            yield return entity.Adapt<CalendarEventDto>();
+        }
+    }
+
+    public async Task<CalendarEventDto?> GetEventAsync(Guid id, Guid userId, CancellationToken ct)
+    {
+        var entity = await _uow.CalendarEvents.GetByIdAsync(id, ct);
+        return entity is null || entity.UserId != userId
+            ? null
+            : entity.Adapt<CalendarEventDto>();
+    }
+
+    public async Task<CalendarEventDto?> UpdateEventAsync(Guid id, CalendarEventUpdateDto dto, Guid userId, CancellationToken ct)
+    {
+        var entity = await _uow.CalendarEvents.GetByIdAsync(id, ct);
+        if (entity is null || entity.UserId != userId)
+        {
+            return null;
+        }
+
+        if (dto.Title is not null)
+        {
+            entity.Title = dto.Title;
+        }
+
+        if (dto.Description is not null)
+        {
+            entity.Description = dto.Description;
+        }
+
+        if (dto.StartDateTime.HasValue)
+        {
+            entity.StartDateTime = dto.StartDateTime.Value;
+        }
+
+        if (dto.EndDateTime.HasValue)
+        {
+            entity.EndDateTime = dto.EndDateTime.Value;
+        }
+
+        if (dto.Type.HasValue)
+        {
+            entity.Type = dto.Type.Value;
+        }
+
+        if (dto.Color is not null)
+        {
+            entity.Color = dto.Color;
+        }
+
+        if (dto.PregnancyId.HasValue)
+        {
+            entity.PregnancyId = dto.PregnancyId.Value;
+        }
+
+        if (dto.Location is not null)
+        {
+            entity.Location = dto.Location;
+        }
+
+        entity.Touch();
+        await _uow.CalendarEvents.UpdateAsync(entity, ct);
+        await _uow.SaveChangesAsync(ct);
+        return entity.Adapt<CalendarEventDto>();
+    }
+}

--- a/src/HolaBebe.Application/Services/ICalendarService.cs
+++ b/src/HolaBebe.Application/Services/ICalendarService.cs
@@ -1,0 +1,19 @@
+using HolaBebe.Application.Dtos;
+using HolaBebe.Domain;
+
+namespace HolaBebe.Application.Services;
+
+public interface ICalendarService
+{
+    IAsyncEnumerable<CalendarEventDto> GetEventsAsync(
+        Guid userId,
+        DateTime? startFrom,
+        DateTime? startTo,
+        CalendarType? type,
+        CancellationToken ct);
+
+    Task<CalendarEventDto> CreateEventAsync(CalendarEventCreateDto dto, Guid userId, CancellationToken ct);
+    Task<CalendarEventDto?> GetEventAsync(Guid id, Guid userId, CancellationToken ct);
+    Task<CalendarEventDto?> UpdateEventAsync(Guid id, CalendarEventUpdateDto dto, Guid userId, CancellationToken ct);
+    Task<bool> DeleteEventAsync(Guid id, Guid userId, CancellationToken ct);
+}

--- a/src/HolaBebe.Infrastructure/Data/CosmosDbUnitOfWork.cs
+++ b/src/HolaBebe.Infrastructure/Data/CosmosDbUnitOfWork.cs
@@ -15,6 +15,7 @@ public sealed class CosmosDbUnitOfWork : IUnitOfWork, IDisposable
     public IGenericRepository<Pregnancy> Pregnancies { get; }
     public IGenericRepository<FruitSizeCatalog> FruitSizes { get; }
     public IGenericRepository<WeeklyContent> WeeklyContents { get; }
+    public IGenericRepository<CalendarEvent> CalendarEvents { get; }
 
     public CosmosDbUnitOfWork(CosmosClient client, IOptions<CosmosSettings> options)
     {
@@ -24,6 +25,7 @@ public sealed class CosmosDbUnitOfWork : IUnitOfWork, IDisposable
         Pregnancies = new CosmosDbRepository<Pregnancy>(_database.CreateContainerIfNotExistsAsync("Pregnancies", "/id").GetAwaiter().GetResult());
         FruitSizes = new CosmosDbRepository<FruitSizeCatalog>(_database.CreateContainerIfNotExistsAsync("FruitSizes", "/id").GetAwaiter().GetResult());
         WeeklyContents = new CosmosDbRepository<WeeklyContent>(_database.CreateContainerIfNotExistsAsync("WeeklyContents", "/id").GetAwaiter().GetResult());
+        CalendarEvents = new CosmosDbRepository<CalendarEvent>(_database.CreateContainerIfNotExistsAsync("CalendarEvents", "/id").GetAwaiter().GetResult());
     }
 
     public Task<int> SaveChangesAsync(CancellationToken ct) => Task.FromResult(0);


### PR DESCRIPTION
## Summary
- add new API endpoints for Calendar Events
- implement `CalendarService` with CRUD operations
- update DI and unit of work to handle calendar events
- document endpoints and DTOs in OpenAPI spec

## Testing
- `dotnet format --verify-no-changes` *(fails: command not found)*
- `dotnet build -c Release` *(fails: command not found)*
- `dotnet test /p:CollectCoverage=true` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e19f9b8e8833391437f8652814a41