### PR TITLE
Implement weekly content, blog and tutorial APIs

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -194,6 +194,78 @@ paths:
           description: No Content
         '404':
           description: Not Found
+  /weekly-content/{week}/{category}:
+    get:
+      summary: Get weekly content by category
+      parameters:
+        - in: path
+          name: week
+          schema:
+            type: integer
+          required: true
+        - in: path
+          name: category
+          schema:
+            type: integer
+          required: true
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WeeklyContentDto'
+        '404':
+          description: Not Found
+  /articles:
+    get:
+      summary: List articles
+      parameters:
+        - in: query
+          name: page
+          schema:
+            type: integer
+        - in: query
+          name: pageSize
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PagedArticleListDto'
+  /articles/{slug}:
+    get:
+      summary: Get article by slug
+      parameters:
+        - in: path
+          name: slug
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ArticleDto'
+        '404':
+          description: Not Found
+  /tutorial-slides:
+    get:
+      summary: List tutorial slides
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TutorialSlideDto'
 components:
   schemas:
     PregnancyCreateDto:
@@ -308,18 +380,81 @@ components:
           type: string
         location:
           type: string
-    CalendarEventDto:
-      type: object
-      properties:
-        id:
+  CalendarEventDto:
+    type: object
+    properties:
+      id:
+        type: string
+      title:
+        type: string
+      startDateTime:
+        type: string
+        format: date-time
+      type:
+        type: integer
+      color:
+        type: string
+  WeeklyContentDto:
+    type: object
+    properties:
+      title:
+        type: string
+      htmlContent:
+        type: string
+      videoUrl:
+        type: string
+  ArticleListDto:
+    type: object
+    properties:
+      slug:
+        type: string
+      title:
+        type: string
+      excerpt:
+        type: string
+      coverImageUrl:
+        type: string
+      publishedAt:
+        type: string
+        format: date-time
+  ArticleDto:
+    type: object
+    properties:
+      title:
+        type: string
+      htmlContent:
+        type: string
+      tags:
+        type: array
+        items:
           type: string
-        title:
-          type: string
-        startDateTime:
-          type: string
-          format: date-time
-        type:
-          type: integer
-        color:
-          type: string
+      author:
+        type: string
+      publishedAt:
+        type: string
+        format: date-time
+  PagedArticleListDto:
+    type: object
+    properties:
+      items:
+        type: array
+        items:
+          $ref: '#/components/schemas/ArticleListDto'
+      total:
+        type: integer
+      page:
+        type: integer
+      pageSize:
+        type: integer
+  TutorialSlideDto:
+    type: object
+    properties:
+      order:
+        type: integer
+      title:
+        type: string
+      subtitle:
+        type: string
+      imageUrl:
+        type: string
 

--- a/src/HolaBebe.Api/Program.cs
+++ b/src/HolaBebe.Api/Program.cs
@@ -209,6 +209,52 @@ api.MapDelete("/calendar-events/{id}", async (Guid id, HttpContext http, ICalend
     .Produces(StatusCodes.Status404NotFound)
     .WithOpenApi();
 
+api.MapGet("/weekly-content/{week:int}/{category:int}", async (int week, int category, IWeeklyContentService svc, CancellationToken ct) =>
+    {
+        var content = await svc.GetContentAsync(week, (WeeklyCategory)category, ct);
+        return content is null ? Results.NotFound() : Results.Ok(content);
+    })
+    .WithName("GetWeeklyContent")
+    .WithSummary("Get weekly content by category")
+    .Produces<WeeklyContentDto>(StatusCodes.Status200OK)
+    .Produces(StatusCodes.Status404NotFound)
+    .WithOpenApi();
+
+api.MapGet("/articles", async (int? page, int? pageSize, IArticleService svc, CancellationToken ct) =>
+    {
+        var result = await svc.GetArticlesAsync(page ?? 1, pageSize ?? 10, ct);
+        return Results.Ok(result);
+    })
+    .WithName("ListArticles")
+    .WithSummary("List articles")
+    .Produces<PagedResultDto<ArticleListDto>>(StatusCodes.Status200OK)
+    .WithOpenApi();
+
+api.MapGet("/articles/{slug}", async (string slug, IArticleService svc, CancellationToken ct) =>
+    {
+        var article = await svc.GetArticleAsync(slug, ct);
+        return article is null ? Results.NotFound() : Results.Ok(article);
+    })
+    .WithName("GetArticle")
+    .WithSummary("Get article by slug")
+    .Produces<ArticleDto>(StatusCodes.Status200OK)
+    .Produces(StatusCodes.Status404NotFound)
+    .WithOpenApi();
+
+api.MapGet("/tutorial-slides", async (ITutorialService svc, CancellationToken ct) =>
+    {
+        var list = new List<TutorialSlideDto>();
+        await foreach (var slide in svc.GetSlidesAsync(ct))
+        {
+            list.Add(slide);
+        }
+        return Results.Ok(list);
+    })
+    .WithName("ListTutorialSlides")
+    .WithSummary("List tutorial slides")
+    .Produces<IList<TutorialSlideDto>>(StatusCodes.Status200OK)
+    .WithOpenApi();
+
 static Guid GetUserId(ClaimsPrincipal user, IConfiguration cfg)
 {
     var claim = user.FindFirst(ClaimTypes.NameIdentifier)?.Value;

--- a/src/HolaBebe.Application/Dtos/PagedResultDto.cs
+++ b/src/HolaBebe.Application/Dtos/PagedResultDto.cs
@@ -1,0 +1,9 @@
+namespace HolaBebe.Application.Dtos;
+
+public sealed class PagedResultDto<T>
+{
+    public IReadOnlyCollection<T> Items { get; init; } = Array.Empty<T>();
+    public int Total { get; init; }
+    public int Page { get; init; }
+    public int PageSize { get; init; }
+}

--- a/src/HolaBebe.Application/Dtos/WeeklyContentDto.cs
+++ b/src/HolaBebe.Application/Dtos/WeeklyContentDto.cs
@@ -1,0 +1,8 @@
+namespace HolaBebe.Application.Dtos;
+
+public sealed class WeeklyContentDto
+{
+    public string Title { get; init; } = string.Empty;
+    public string HtmlContent { get; init; } = string.Empty;
+    public string? VideoUrl { get; init; }
+}

--- a/src/HolaBebe.Application/Interfaces/IUnitOfWork.cs
+++ b/src/HolaBebe.Application/Interfaces/IUnitOfWork.cs
@@ -9,5 +9,7 @@ public interface IUnitOfWork
     IGenericRepository<FruitSizeCatalog> FruitSizes { get; }
     IGenericRepository<WeeklyContent> WeeklyContents { get; }
     IGenericRepository<CalendarEvent> CalendarEvents { get; }
+    IGenericRepository<Article> Articles { get; }
+    IGenericRepository<TutorialSlide> TutorialSlides { get; }
     Task<int> SaveChangesAsync(CancellationToken ct);
 }

--- a/src/HolaBebe.Application/Mapping/MappingConfig.cs
+++ b/src/HolaBebe.Application/Mapping/MappingConfig.cs
@@ -23,5 +23,6 @@ public static class MappingConfig
         TypeAdapterConfig<Article, ArticleDto>.NewConfig();
 
         TypeAdapterConfig<TutorialSlide, TutorialSlideDto>.NewConfig();
+        TypeAdapterConfig<WeeklyContent, WeeklyContentDto>.NewConfig();
     }
 }

--- a/src/HolaBebe.Application/ServiceCollectionExtensions.cs
+++ b/src/HolaBebe.Application/ServiceCollectionExtensions.cs
@@ -10,6 +10,9 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IProfileService, ProfileService>();
         services.AddScoped<IPregnancyService, PregnancyService>();
         services.AddScoped<ICalendarService, CalendarService>();
+        services.AddScoped<IWeeklyContentService, WeeklyContentService>();
+        services.AddScoped<IArticleService, ArticleService>();
+        services.AddScoped<ITutorialService, TutorialService>();
         return services;
     }
 }

--- a/src/HolaBebe.Application/Services/ArticleService.cs
+++ b/src/HolaBebe.Application/Services/ArticleService.cs
@@ -1,0 +1,49 @@
+using HolaBebe.Application.Dtos;
+using HolaBebe.Application.Interfaces;
+using HolaBebe.Domain.Entities;
+using Mapster;
+
+namespace HolaBebe.Application.Services;
+
+public sealed class ArticleService : IArticleService
+{
+    private readonly IUnitOfWork _uow;
+
+    public ArticleService(IUnitOfWork uow) => _uow = uow;
+
+    public async Task<PagedResultDto<ArticleListDto>> GetArticlesAsync(int page, int pageSize, CancellationToken ct)
+    {
+        if (page < 1) page = 1;
+        if (pageSize < 1) pageSize = 10;
+
+        var list = new List<ArticleListDto>();
+        var all = new List<Article>();
+        await foreach (var a in _uow.Articles.GetAsync(_ => true, ct))
+        {
+            all.Add(a);
+        }
+
+        var total = all.Count;
+        foreach (var item in all.OrderByDescending(a => a.PublishedAt).Skip((page - 1) * pageSize).Take(pageSize))
+        {
+            list.Add(item.Adapt<ArticleListDto>());
+        }
+
+        return new PagedResultDto<ArticleListDto>
+        {
+            Items = list,
+            Total = total,
+            Page = page,
+            PageSize = pageSize
+        };
+    }
+
+    public async Task<ArticleDto?> GetArticleAsync(string slug, CancellationToken ct)
+    {
+        await foreach (var a in _uow.Articles.GetAsync(a => a.Slug == slug, ct))
+        {
+            return a.Adapt<ArticleDto>();
+        }
+        return null;
+    }
+}

--- a/src/HolaBebe.Application/Services/IArticleService.cs
+++ b/src/HolaBebe.Application/Services/IArticleService.cs
@@ -1,0 +1,9 @@
+using HolaBebe.Application.Dtos;
+
+namespace HolaBebe.Application.Services;
+
+public interface IArticleService
+{
+    Task<PagedResultDto<ArticleListDto>> GetArticlesAsync(int page, int pageSize, CancellationToken ct);
+    Task<ArticleDto?> GetArticleAsync(string slug, CancellationToken ct);
+}

--- a/src/HolaBebe.Application/Services/ITutorialService.cs
+++ b/src/HolaBebe.Application/Services/ITutorialService.cs
@@ -1,0 +1,8 @@
+using HolaBebe.Application.Dtos;
+
+namespace HolaBebe.Application.Services;
+
+public interface ITutorialService
+{
+    IAsyncEnumerable<TutorialSlideDto> GetSlidesAsync(CancellationToken ct);
+}

--- a/src/HolaBebe.Application/Services/IWeeklyContentService.cs
+++ b/src/HolaBebe.Application/Services/IWeeklyContentService.cs
@@ -1,0 +1,9 @@
+using HolaBebe.Application.Dtos;
+using HolaBebe.Domain;
+
+namespace HolaBebe.Application.Services;
+
+public interface IWeeklyContentService
+{
+    Task<WeeklyContentDto?> GetContentAsync(int week, WeeklyCategory category, CancellationToken ct);
+}

--- a/src/HolaBebe.Application/Services/TutorialService.cs
+++ b/src/HolaBebe.Application/Services/TutorialService.cs
@@ -1,0 +1,25 @@
+using HolaBebe.Application.Dtos;
+using HolaBebe.Application.Interfaces;
+using Mapster;
+
+namespace HolaBebe.Application.Services;
+
+public sealed class TutorialService : ITutorialService
+{
+    private readonly IUnitOfWork _uow;
+
+    public TutorialService(IUnitOfWork uow) => _uow = uow;
+
+    public async IAsyncEnumerable<TutorialSlideDto> GetSlidesAsync([System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)
+    {
+        var list = new List<TutorialSlideDto>();
+        await foreach (var slide in _uow.TutorialSlides.GetAsync(_ => true, ct))
+        {
+            list.Add(slide.Adapt<TutorialSlideDto>());
+        }
+        foreach (var item in list.OrderBy(s => s.Order))
+        {
+            yield return item;
+        }
+    }
+}

--- a/src/HolaBebe.Application/Services/WeeklyContentService.cs
+++ b/src/HolaBebe.Application/Services/WeeklyContentService.cs
@@ -1,0 +1,23 @@
+using HolaBebe.Application.Dtos;
+using HolaBebe.Application.Interfaces;
+using HolaBebe.Domain;
+using HolaBebe.Domain.Entities;
+using Mapster;
+
+namespace HolaBebe.Application.Services;
+
+public sealed class WeeklyContentService : IWeeklyContentService
+{
+    private readonly IUnitOfWork _uow;
+
+    public WeeklyContentService(IUnitOfWork uow) => _uow = uow;
+
+    public async Task<WeeklyContentDto?> GetContentAsync(int week, WeeklyCategory category, CancellationToken ct)
+    {
+        await foreach (var item in _uow.WeeklyContents.GetAsync(c => c.Week == week && c.Category == category, ct))
+        {
+            return item.Adapt<WeeklyContentDto>();
+        }
+        return null;
+    }
+}

--- a/src/HolaBebe.Infrastructure/Data/CosmosDbUnitOfWork.cs
+++ b/src/HolaBebe.Infrastructure/Data/CosmosDbUnitOfWork.cs
@@ -16,6 +16,8 @@ public sealed class CosmosDbUnitOfWork : IUnitOfWork, IDisposable
     public IGenericRepository<FruitSizeCatalog> FruitSizes { get; }
     public IGenericRepository<WeeklyContent> WeeklyContents { get; }
     public IGenericRepository<CalendarEvent> CalendarEvents { get; }
+    public IGenericRepository<Article> Articles { get; }
+    public IGenericRepository<TutorialSlide> TutorialSlides { get; }
 
     public CosmosDbUnitOfWork(CosmosClient client, IOptions<CosmosSettings> options)
     {
@@ -26,6 +28,8 @@ public sealed class CosmosDbUnitOfWork : IUnitOfWork, IDisposable
         FruitSizes = new CosmosDbRepository<FruitSizeCatalog>(_database.CreateContainerIfNotExistsAsync("FruitSizes", "/id").GetAwaiter().GetResult());
         WeeklyContents = new CosmosDbRepository<WeeklyContent>(_database.CreateContainerIfNotExistsAsync("WeeklyContents", "/id").GetAwaiter().GetResult());
         CalendarEvents = new CosmosDbRepository<CalendarEvent>(_database.CreateContainerIfNotExistsAsync("CalendarEvents", "/id").GetAwaiter().GetResult());
+        Articles = new CosmosDbRepository<Article>(_database.CreateContainerIfNotExistsAsync("Articles", "/id").GetAwaiter().GetResult());
+        TutorialSlides = new CosmosDbRepository<TutorialSlide>(_database.CreateContainerIfNotExistsAsync("TutorialSlides", "/id").GetAwaiter().GetResult());
     }
 
     public Task<int> SaveChangesAsync(CancellationToken ct) => Task.FromResult(0);


### PR DESCRIPTION
## Summary
- support fetching weekly curated content per category
- add blog article listing and retrieval endpoints
- expose tutorial slides for onboarding
- wire up application services and data repositories
- document the new APIs in OpenAPI spec

## Testing
- `dotnet format --verify-no-changes` *(fails: command not found)*
- `dotnet build -c Release` *(fails: command not found)*
- `dotnet test /p:CollectCoverage=true` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e1b8d779083338193ba8fe5133f73